### PR TITLE
refactor: Use hasOwn instead of hasOwnProperty

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
         SharedArrayBuffer: "readonly",
     },
     parserOptions: {
-        ecmaVersion: 2018,
+        ecmaVersion: "latest",
         sourceType: "module",
     },
     rules: {},

--- a/src/subscribers/get.js
+++ b/src/subscribers/get.js
@@ -19,7 +19,7 @@ exports.getHandler = event => {
         }
 
         const hasOwnParams = (key, value) => {
-            const hasOwnKey = Object.prototype.hasOwnProperty.call(queryStringParams, key)
+            const hasOwnKey = Object.hasOwn(queryStringParams, key)
             return value ? hasOwnKey && queryStringParams[key] === value : hasOwnKey
         }
 


### PR DESCRIPTION
## Description

프로젝트에서 기존에 사용하던`Object.prototype.hasOwnProperty()`를 `Object.hasOwn()`로 변경함.

`Object.prototype.hasOwnProperty()` 를 대체하기 위해 제안된 `Object.hasOwn()`는 정적 메서드로 구현되었기 때문에 특정 인스턴스의 프로토타입 상속 관계에 구애받지 않고 사용 가능하다는 장점이 있음. 

## References
[https://github.com/tc39/proposal-accessible-object-hasownproperty](https://github.com/tc39/proposal-accessible-object-hasownproperty)