### PR TITLE
refactor: Use setup-node to cache dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,18 +16,7 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-
-            - name: Get npm cache directory path
-              id: npm-cache-dir
-              run: echo "::set-output name=dir::$(npm config get cache)"
-
-            - uses: actions/cache@v3
-              id: npm-cache
-              with:
-                  path: ${{ steps.npm-cache-dir.outputs.dir }}
-                  key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-Node-v${{ matrix.node-version }}-
+                  cache: npm
 
             - name: Install dependencies
               run: npm install

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -16,18 +16,7 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-
-            - name: Get npm cache directory path
-              id: npm-cache-dir
-              run: echo "::set-output name=dir::$(npm config get cache)"
-
-            - uses: actions/cache@v3
-              id: npm-cache
-              with:
-                  path: ${{ steps.npm-cache-dir.outputs.dir }}
-                  key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-Node-v${{ matrix.node-version }}-
+                  cache: npm
 
             - name: Install dependencies
               run: npm install


### PR DESCRIPTION
## Description

기존  [actions/cache](https://github.com/actions/cache)룰 통하여 사용하던 `의존성 캐싱` 기능을 [actions/setup-node](https://github.com/actions/setup-node)에 내장된 기능으로 대체함.
