### PR TITLE
chore: Update workflows to install packages based on lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                   cache: npm
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Lint
               run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
                   cache: npm
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Run npm build
               run: npm run build --if-present


### PR DESCRIPTION
## Description

워크플로우에서 lock 파일을 기준으로 패키지를 설치하기 위해 기존의 `npm install` command 대신 `npm ci` command를 사용하도록 변경함.