### PR TITLE
chore: Update prettier version to v2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
                 "jest": "^29.3.1",
-                "prettier": "^2.7.1"
+                "prettier": "^2.8.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -3795,9 +3795,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -7468,9 +7468,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
             "dev": true
         },
         "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.3.1",
-        "prettier": "^2.7.1"
+        "prettier": "^2.8.0"
     }
 }


### PR DESCRIPTION
## Description

[prettier@v2.8.0](https://github.com/prettier/prettier/releases/tag/2.8.0) release에 따라 패키지를 최신 버전으로 업데이트함.