### PR TITLE
chore: Update eslint version to v8.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "request": "^2.88.2"
             },
             "devDependencies": {
-                "eslint": "^8.29.0",
+                "eslint": "^8.30.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
                 "jest": "^29.3.1",
@@ -613,15 +613,15 @@
             "dev": true
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^9.4.0",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -636,14 +636,14 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
@@ -1207,9 +1207,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1833,13 +1833,13 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+            "version": "8.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
+                "@eslint/eslintrc": "^1.4.0",
+                "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
@@ -1858,7 +1858,7 @@
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
@@ -2017,9 +2017,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-            "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
@@ -2372,9 +2372,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2470,9 +2470,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+            "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -5038,15 +5038,15 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^9.4.0",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -5055,14 +5055,14 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             }
         },
         "@humanwhocodes/module-importer": {
@@ -5533,9 +5533,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
         },
         "acorn-jsx": {
@@ -5997,13 +5997,13 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+            "version": "8.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
+                "@eslint/eslintrc": "^1.4.0",
+                "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
@@ -6022,7 +6022,7 @@
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
@@ -6123,9 +6123,9 @@
             "dev": true
         },
         "espree": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-            "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "requires": {
                 "acorn": "^8.8.0",
@@ -6389,9 +6389,9 @@
             }
         },
         "globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -6461,9 +6461,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+            "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
             "dev": true
         },
         "import-fresh": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "request": "^2.88.2"
     },
     "devDependencies": {
-        "eslint": "^8.29.0",
+        "eslint": "^8.30.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.3.1",


### PR DESCRIPTION
## Description

[eslint@v8.30.0](https://github.com/eslint/eslint/releases/tag/v8.30.0) release에 따라 패키지를 최신 버전으로 업데이트함.